### PR TITLE
Moved cursor position in the middle

### DIFF
--- a/CComment/CComment.m
+++ b/CComment/CComment.m
@@ -88,7 +88,7 @@ static CComment *sharedPlugin;
     NSString *commented = [self commentString:textView.textStorage.string range:&range];
     
     if (commented != nil) {
-        [Xcode replaceCharactersInRange:range withString:commented];
+        [Xcode replaceCharactersInRange:range withString:commented andOptionEnabled:[self isOptionEnabled]];
     }
 }
 

--- a/CComment/Xcode.h
+++ b/CComment/Xcode.h
@@ -12,7 +12,7 @@
 
 + (id)currentEditor;
 + (NSTextView *)textView;
-+ (void)replaceCharactersInRange:(NSRange)range withString:(NSString *)aString;
++ (void)replaceCharactersInRange:(NSRange)range withString:(NSString *)aString andOptionEnabled:(BOOL)optionEnabled;
 //+ (void)setupKeyBinding;
 
 @end

--- a/CComment/Xcode.m
+++ b/CComment/Xcode.m
@@ -99,7 +99,7 @@
     return nil;
 }
 
-+ (void)replaceCharactersInRange:(NSRange)range withString:(NSString *)aString
++ (void)replaceCharactersInRange:(NSRange)range withString:(NSString *)aString andOptionEnabled:(BOOL)optionEnabled
 {
     IDESourceCodeDocument * document = [self sourceCodeDocument];
     if ( !document )
@@ -107,6 +107,8 @@
     [[document textStorage] beginEditing];
     [[document textStorage] replaceCharactersInRange:range withString:aString withUndoManager:[document undoManager]];
     [[document textStorage] endEditing];
+
+    [[self textView] setSelectedRange:NSMakeRange(range.location + aString.length - (optionEnabled ? 3 : 2), 0)];
 }
 
 @end


### PR DESCRIPTION
If the `Leading/Trailing Space` is enabled and:
- if the plugin is triggered with selected text:
  - `comment` would transform into `/* comment| */`, where the `|` is the cursor position
  - else, at the cursor position would be inserted `/* | */`
- else, if the plugin is triggered with selected text:
  - `comment` would transform into `/*comment|*/`, where the `|` is the cursor position
  - else, at the cursor position would be inserted `/*|*/`

so you can immediately start typing or editing the comment.
