### PR TITLE
Support Xcode 7.1 GM

### DIFF
--- a/CComment/CComment-Info.plist
+++ b/CComment/CComment-Info.plist
@@ -38,6 +38,7 @@
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
 		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
+		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
 	</array>
 	<key>XC4Compatible</key>
 	<true/>


### PR DESCRIPTION
Added Xcode 7.1 GM UUID to CComment-Info.plist to support Xcode 7.1 GM out of the box.
